### PR TITLE
Fix deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.111.3
+      HUGO_VERSION: 0.140.2
     steps:
       - name: Install Hugo CLI
         run: |
@@ -41,13 +41,13 @@ jobs:
       - name: Install Dart Sass Embedded
         run: sudo snap install dart-sass-embedded
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 
@@ -75,4 +75,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR addresses the build error: "deprecated version of actions/upload-artifact: v3"

Changes:
- actions/checkout: v3 → v4
- actions/configure-pages: v3 → v5
- actions/upload-pages-artifact: v1 → v3 (fixes the deprecation error)
- actions/deploy-pages: v2 → v4
- Hugo version: 0.111.3 → 0.140.2 (latest stable release)

The upload-pages-artifact@v1 was using the deprecated upload-artifact@v3 internally, which GitHub deprecated in April 2024. Updating to v3 resolves this issue and ensures the workflow runs successfully.