### PR TITLE
Fix Hugo deprecated Site.Social error

### DIFF
--- a/themes/hugo-geekblog/layouts/partials/microformats/opengraph.html
+++ b/themes/hugo-geekblog/layouts/partials/microformats/opengraph.html
@@ -61,6 +61,6 @@
 {{- end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
-{{- with .Site.Social.facebook_admin }}
+{{- with .Site.Params.Social.facebook_admin }}
   <meta property="fb:admins" content="{{ . }}" />
 {{- end }}

--- a/themes/hugo-geekblog/layouts/partials/microformats/twitter_cards.html
+++ b/themes/hugo-geekblog/layouts/partials/microformats/twitter_cards.html
@@ -10,6 +10,6 @@
 {{- with partial "utils/description" . }}
   <meta name="twitter:description" content="{{ . | plainify | htmlUnescape | chomp }}" />
 {{- end }}
-{{- with .Site.Social.twitter -}}
+{{- with .Site.Params.Social.twitter -}}
   <meta name="twitter:site" content="@{{ . }}" />
 {{- end }}


### PR DESCRIPTION
Replace .Site.Social with .Site.Params.Social to resolve Hugo v0.140.2 deprecation warning. This change prevents build failures in Hugo 0.141.0+.

Updated files:
- themes/hugo-geekblog/layouts/partials/microformats/opengraph.html
- themes/hugo-geekblog/layouts/partials/microformats/twitter_cards.html